### PR TITLE
Fix small backend issues

### DIFF
--- a/backend/src/routes/graph.ts
+++ b/backend/src/routes/graph.ts
@@ -26,5 +26,3 @@ router.post('/edge', upsertEdge);
 router.delete('/edge/:id', deleteEdge);
 
 export default router;
-
-module.exports = router;

--- a/backend/tests/seed.js
+++ b/backend/tests/seed.js
@@ -1,10 +1,10 @@
 const mongoose = require('mongoose');
 const fs = require('fs');
 const path = require('path');
-const kpiElement = require('../schmas/kpiElement');
-const kpiNode = require('../schmas/kpiNode');
-const kpiEdge = require('../schmas/kpiEdge');
-const kpiGroup = require('../schmas/kpiGroup');
+const kpiElement = require('../schemas/kpiElement');
+const kpiNode = require('../schemas/kpiNode');
+const kpiEdge = require('../schemas/kpiEdge');
+const kpiGroup = require('../schemas/kpiGroup');
 
 const mongoURI = process.env.MONGODB_DEV || 'mongodb://localhost:27017/dev';
 


### PR DESCRIPTION
## Summary
- remove leftover `module.exports` from graph router
- fix typo in test seed script

## Testing
- `npm test --silent` *(fails: exceeded timeout for DB-related tests)*

------
https://chatgpt.com/codex/tasks/task_e_686f3ebcb128832eb748cfedd704d153